### PR TITLE
複数枚画像投稿機能

### DIFF
--- a/app/assets/stylesheets/items/show.css
+++ b/app/assets/stylesheets/items/show.css
@@ -33,6 +33,24 @@
   object-fit: contain;
 }
 
+/* プレビュー */
+.image-list {
+  margin-top: 10px;
+  width: 60vw;
+  display: flex;
+  background-color: rgb(205, 202, 202);
+  justify-content: space-between;
+}
+
+.image-list .images {
+  padding: 15px 0;
+  width: 47%;
+  height: auto;
+  max-height: 500px;
+  object-fit: contain;
+}
+/* プレビュー */
+
 .item-price-box {
   margin: 25px 0px;
   display: flex;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -43,7 +43,7 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item).permit(
-      :image, :name, :description, :category_id, :item_status_id, :delivery_fee_id, :province_id, :delivery_days_id, :price
+      :name, :description, :category_id, :item_status_id, :delivery_fee_id, :province_id, :delivery_days_id, :price, images: []
     ).merge(user_id: current_user.id)
   end
 

--- a/app/javascript/preview.js
+++ b/app/javascript/preview.js
@@ -4,22 +4,44 @@ document.addEventListener('DOMContentLoaded', () => {
 
     //生成した画像を表示する関数
     const createImageHTML = (blob) => {
-      //画像を表示するための要素を生成
+      //画像を表示するためのdiv要素を生成
       const imageElement = document.createElement('div');
+      imageElement.setAttribute('class', "image-element")
+      let imageElementNum = document.querySelectorAll('.image-element').length;
+
+      // 表示する画像を生成
       const blobImage = document.createElement('img');
       blobImage.setAttribute('src', blob);
 
+      // ファイル選択ボタンを生成
+      const inputHTML = document.createElement('input');
+      inputHTML.setAttribute('id', `item-image-${ imageElementNum }`);
+      inputHTML.setAttribute('name', 'item[images][]');
+      inputHTML.setAttribute('type', 'file');
+
       //生成したHTMLの要素をブラウザに表示させる
       imageElement.appendChild(blobImage);
+      imageElement.appendChild(inputHTML);
       ImageList.appendChild(imageElement);
-    }
+
+      inputHTML.addEventListener('change', (e) => {
+        file = e.target.files[0];
+        blob = window.URL.createObjectURL(file);
+
+        createImageHTML(blob);
+      });
+    };
 
     //画像を取得してURLを生成
     document.getElementById('item-image').addEventListener('change', (e) => {
-      const imageContent = document.querySelector('.click-upload img');
-      if (imageContent){
-        imageContent.remove();
-      }
+
+      // 1枚投稿時のプレビュー枚数制限
+      // const imageContent = document.querySelector('.click-upload img');
+      // if (imageContent){
+      //   imageContent.remove();
+      // }
+      // 1枚投稿時のプレビュー枚数制限
+
       const file = e.target.files[0];
       const blob = window.URL.createObjectURL(file);
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,7 +1,7 @@
 class Item < ApplicationRecord
   # バリデーションの設定
   with_options presence: true do
-    validates :image
+    validates :images
     validates :name
     validates :description
   end
@@ -19,7 +19,7 @@ class Item < ApplicationRecord
   numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999 }
 
   # アソシエーションの設定
-  has_one_attached :image
+  has_many_attached :images
   belongs_to :user
   has_one :order
 

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -23,7 +23,9 @@ app/assets/stylesheets/items/new.css %>
         </p>
         <%= f.file_field :image, id:"item-image" %>
         <div id="image-list"></div>
-        <%= image_tag @item.image %>
+        <% @item.images.each do |image| %>
+          <%= image_tag image, class: 'images' %>
+        <% end %>
       </div>
     </div>
     <%# /商品画像 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,7 +131,7 @@
         <li class='list'>
           <%= link_to item_path(item.id) do %>
           <div class='item-img-content'>
-            <%= image_tag item.image, class: "item-img" if item.image.attached? %>
+            <%= image_tag item.images[0], class: "item-img" if item.images.attached? %>
 
             <%# 売り切れ商品に画像を表示 %>
             <% if item.order.present? %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -19,7 +19,7 @@
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :image, id:"item-image" %>
+        <%= f.file_field :images, name:'item[images][]', id:"item-image" %>
         <div id="image-list"></div>
       </div>
     </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,7 +7,7 @@
       <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag @item.image ,class:"item-box-img" if @item.image.attached? %>
+      <%= image_tag @item.images[0] ,class:"item-box-img" if @item.images.attached? %>
 
       <%# 売り切れ商品に画像を表示 %>
       <% if @item.order.present? %>
@@ -15,8 +15,17 @@
         <span>Sold Out!!</span>
       </div>
       <% end  %>
-
     </div>
+
+    <%# 商品画像複数表示 %>
+    <div class="image-list">
+      <% if @item.images.length > 1 %>
+        <% @item.images.each do |image| %>
+          <%= image_tag image, class: 'images' %>
+        <% end %>
+      <% end  %>
+    </div>
+
     <div class="item-price-box">
       <span class="item-price">
         ¥ <%= @item.price %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -7,7 +7,7 @@
     </h1>
     <%# 購入内容の表示 %>
     <div class='buy-item-info'>
-      <%= image_tag @item.image, class: 'buy-item-img' if @item.image.attached? %>
+      <%= image_tag @item.images[0], class: 'buy-item-img' if @item.images.attached? %>
       <div class='buy-item-right-content'>
         <h2 class='buy-item-text'>
           <%= @item.name %>

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     association :user
 
     after(:build) do |item|
-      item.image.attach(io: File.open('public/images/test_image.png'), filename: 'test_image.png')
+      item.images.attach(io: File.open('public/images/test_image.png'), filename: 'test_image.png')
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe Item, type: :model do
 
     context '出品できないとき' do
       it '商品画像がないと出品できない' do
-        @item.image = nil
+        @item.images = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Image can't be blank")
+        expect(@item.errors.full_messages).to include("Images can't be blank")
       end
 
       it '商品名が空では出品できない' do


### PR DESCRIPTION
# What
複数枚画像投稿機能の実装

# Why
複数枚画像を投稿できるようにすることで、購入者に商品情報をより詳細に伝えることができるため。
- アピールポイントを増やす
- 角度を変えて傷や痛みが無い部分・ある部分を証明できる